### PR TITLE
Support `config.basePath`

### DIFF
--- a/packages/config-array/src/base-schema.js
+++ b/packages/config-array/src/base-schema.js
@@ -46,6 +46,7 @@ export const baseSchema = Object.freeze({
 			}
 		},
 	},
+	basePath: NOOP_STRATEGY,
 	files: NOOP_STRATEGY,
 	ignores: NOOP_STRATEGY,
 });

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -496,7 +496,7 @@ function shouldIgnorePath(configs, filePath, relativeFilePath, path) {
 
 	for (const config of configs) {
 		const relativeFilePathToCheck = config.basePath
-			? toRelativePath(filePath, config.basePath, path)
+			? `${toRelativePath(filePath, config.basePath, path)}${relativeFilePath.endsWith("/") ? "/" : ""}`
 			: relativeFilePath;
 		shouldIgnore = config.ignores.reduce((ignored, matcher) => {
 			if (!ignored) {

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -75,7 +75,7 @@ const CONFIG_TYPES = new Set(["array", "function"]);
  * Fields that are considered metadata and not part of the config object.
  * @type {Set<string>}
  */
-const META_FIELDS = new Set(["name"]);
+const META_FIELDS = new Set(["name", "basePath"]);
 
 /**
  * A schema containing just files and ignores for early validation.
@@ -470,37 +470,43 @@ function normalizeSync(
 /**
  * Determines if a given file path should be ignored based on the given
  * matcher.
- * @param {Array<string|((string) => boolean)>} ignores The ignore patterns to check.
+ * @param {Array<{ basePath?: string, ignores: Array<string|((string) => boolean)>}>} configs Configuration objects containing `ignores`.
  * @param {string} filePath The unprocessed file path to check.
  * @param {string} relativeFilePath The path of the file to check relative to the base path,
  * 		using forward slash (`"/"`) as a separator.
  * @returns {boolean} True if the path should be ignored and false if not.
  */
-function shouldIgnorePath(ignores, filePath, relativeFilePath) {
-	return ignores.reduce((ignored, matcher) => {
-		if (!ignored) {
-			if (typeof matcher === "function") {
-				return matcher(filePath);
+function shouldIgnorePath(configs, filePath, relativeFilePath) {
+	let shouldIgnore = false;
+
+	for (const config of configs) {
+		shouldIgnore = config.ignores.reduce((ignored, matcher) => {
+			if (!ignored) {
+				if (typeof matcher === "function") {
+					return matcher(filePath);
+				}
+
+				// don't check negated patterns because we're not ignored yet
+				if (!matcher.startsWith("!")) {
+					return doMatch(relativeFilePath, matcher);
+				}
+
+				// otherwise we're still not ignored
+				return false;
 			}
 
-			// don't check negated patterns because we're not ignored yet
-			if (!matcher.startsWith("!")) {
-				return doMatch(relativeFilePath, matcher);
+			// only need to check negated patterns because we're ignored
+			if (typeof matcher === "string" && matcher.startsWith("!")) {
+				return !doMatch(relativeFilePath, matcher, {
+					flipNegate: true,
+				});
 			}
 
-			// otherwise we're still not ignored
-			return false;
-		}
+			return ignored;
+		}, shouldIgnore);
+	}
 
-		// only need to check negated patterns because we're ignored
-		if (typeof matcher === "string" && matcher.startsWith("!")) {
-			return !doMatch(relativeFilePath, matcher, {
-				flipNegate: true,
-			});
-		}
-
-		return ignored;
-	}, false);
+	return shouldIgnore;
 }
 
 /**
@@ -516,7 +522,11 @@ function shouldIgnorePath(ignores, filePath, relativeFilePath) {
 function pathMatchesIgnores(filePath, relativeFilePath, config) {
 	return (
 		Object.keys(config).filter(key => !META_FIELDS.has(key)).length > 1 &&
-		!shouldIgnorePath(config.ignores, filePath, relativeFilePath)
+		!shouldIgnorePath(
+			[{ ignores: config.ignores }],
+			filePath,
+			relativeFilePath,
+		)
 	);
 }
 
@@ -561,7 +571,7 @@ function pathMatches(filePath, relativeFilePath, config) {
 	 */
 	if (filePathMatchesPattern && config.ignores) {
 		filePathMatchesPattern = !shouldIgnorePath(
-			config.ignores,
+			[{ ignores: config.ignores }],
 			filePath,
 			relativeFilePath,
 		);
@@ -824,7 +834,7 @@ export class ConfigArray extends Array {
 	 * the matching `files` fields in any configs. This is necessary to mimic
 	 * the behavior of things like .gitignore and .eslintignore, allowing a
 	 * globbing operation to be faster.
-	 * @returns {string[]} An array of string patterns and functions to be ignored.
+	 * @returns {Object[]} An array of config objects representing global ignores.
 	 */
 	get ignores() {
 		assertNormalized(this);
@@ -851,7 +861,7 @@ export class ConfigArray extends Array {
 				Object.keys(config).filter(key => !META_FIELDS.has(key))
 					.length === 1
 			) {
-				result.push(...config.ignores);
+				result.push(config);
 			}
 		}
 

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -283,16 +283,22 @@ function needsPatternNormalization(pattern) {
 /**
  * Normalizes `files` and `ignores` patterns in a config by removing "./" prefixes.
  * @param {Object} config The config object to normalize patterns in.
+ * @param {string} namespacedBasePath The namespaced base path of the directory to which config base path is relative.
+ * @param {PathImpl} path Path-handling implementation.
  * @returns {Object} The normalized config object.
  */
-function normalizeConfigPatterns(config) {
+function normalizeConfigPatterns(config, namespacedBasePath, path) {
 	if (!config) {
 		return config;
 	}
 
 	let needsNormalization = false;
 
-	if (Array.isArray(config.files)) {
+	if (typeof config.basePath === "string") {
+		needsNormalization = true;
+	}
+
+	if (!needsNormalization && Array.isArray(config.files)) {
 		needsNormalization = config.files.some(pattern => {
 			if (Array.isArray(pattern)) {
 				return pattern.some(needsPatternNormalization);
@@ -310,6 +316,14 @@ function normalizeConfigPatterns(config) {
 	}
 
 	const newConfig = { ...config };
+
+	if (typeof config.basePath === "string") {
+		if (path.isAbsolute(config.basePath)) {
+			newConfig.basePath = path.toNamespacedPath(config.basePath);
+		} else {
+			newConfig.basePath = path.join(namespacedBasePath, config.basePath);
+		}
+	}
 
 	if (Array.isArray(newConfig.files)) {
 		newConfig.files = newConfig.files.map(pattern => {
@@ -334,10 +348,18 @@ function normalizeConfigPatterns(config) {
  * @param {Object} context The context object to pass into any function
  *      found.
  * @param {Array<string>} extraConfigTypes The config types to check.
+ * @param {string} namespacedBasePath The namespaced base path of the directory to which config base paths are relative.
+ * @param {PathImpl} path Path-handling implementation.
  * @returns {Promise<Array>} A flattened array containing only config objects.
  * @throws {TypeError} When a config function returns a function.
  */
-async function normalize(items, context, extraConfigTypes) {
+async function normalize(
+	items,
+	context,
+	extraConfigTypes,
+	namespacedBasePath,
+	path,
+) {
 	const allowFunctions = extraConfigTypes.includes("function");
 	const allowArrays = extraConfigTypes.includes("array");
 
@@ -377,7 +399,7 @@ async function normalize(items, context, extraConfigTypes) {
 	const configs = [];
 
 	for await (const config of asyncIterable) {
-		configs.push(normalizeConfigPatterns(config));
+		configs.push(normalizeConfigPatterns(config, namespacedBasePath, path));
 	}
 
 	return configs;
@@ -390,10 +412,18 @@ async function normalize(items, context, extraConfigTypes) {
  * @param {Object} context The context object to pass into any function
  *      found.
  * @param {Array<string>} extraConfigTypes The config types to check.
+ * @param {string} namespacedBasePath The namespaced base path of the directory to which config base paths are relative.
+ * @param {PathImpl} path Path-handling implementation
  * @returns {Array} A flattened array containing only config objects.
  * @throws {TypeError} When a config function returns a function.
  */
-function normalizeSync(items, context, extraConfigTypes) {
+function normalizeSync(
+	items,
+	context,
+	extraConfigTypes,
+	namespacedBasePath,
+	path,
+) {
 	const allowFunctions = extraConfigTypes.includes("function");
 	const allowArrays = extraConfigTypes.includes("array");
 
@@ -431,7 +461,7 @@ function normalizeSync(items, context, extraConfigTypes) {
 	const configs = [];
 
 	for (const config of flatTraverse(items)) {
-		configs.push(normalizeConfigPatterns(config));
+		configs.push(normalizeConfigPatterns(config, namespacedBasePath, path));
 	}
 
 	return configs;
@@ -852,6 +882,8 @@ export class ConfigArray extends Array {
 				this,
 				context,
 				this.extraConfigTypes,
+				this.#namespacedBasePath,
+				this.#path,
 			);
 			this.length = 0;
 			this.push(
@@ -881,6 +913,8 @@ export class ConfigArray extends Array {
 				this,
 				context,
 				this.extraConfigTypes,
+				this.#namespacedBasePath,
+				this.#path,
 			);
 			this.length = 0;
 			this.push(

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -1044,6 +1044,13 @@ export class ConfigArray extends Array {
 				? toRelativePath(filePath, config.basePath, this.#path)
 				: relativeToBaseFilePath;
 
+			if (config.basePath && EXTERNAL_PATH_REGEX.test(relativeFilePath)) {
+				debug(
+					`Skipped config found for ${filePath} (based on config's base path: ${config.basePath}`,
+				);
+				return;
+			}
+
 			if (!config.files) {
 				if (!config.ignores) {
 					debug(`Universal config found for ${filePath}`);

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -468,18 +468,36 @@ function normalizeSync(
 }
 
 /**
+ * Converts a given path to a relative path with all separator characters replaced by forward slashes (`"/"`).
+ * @param {string} fileOrDirPath The unprocessed path to convert.
+ * @param {string} namespacedBasePath The namespaced base path of the directory to which the calculated path shall be relative.
+ * @param {PathImpl} path Path-handling implementations.
+ * @returns {string} A relative path with all separator characters replaced by forward slashes.
+ */
+function toRelativePath(fileOrDirPath, namespacedBasePath, path) {
+	const fullPath = path.resolve(namespacedBasePath, fileOrDirPath);
+	const namespacedFullPath = path.toNamespacedPath(fullPath);
+	const relativePath = path.relative(namespacedBasePath, namespacedFullPath);
+	return relativePath.replaceAll(path.SEPARATOR, "/");
+}
+
+/**
  * Determines if a given file path should be ignored based on the given
  * matcher.
  * @param {Array<{ basePath?: string, ignores: Array<string|((string) => boolean)>}>} configs Configuration objects containing `ignores`.
  * @param {string} filePath The unprocessed file path to check.
  * @param {string} relativeFilePath The path of the file to check relative to the base path,
  * 		using forward slash (`"/"`) as a separator.
+ * @param {PathImpl} [path] Path-handling implementations.
  * @returns {boolean} True if the path should be ignored and false if not.
  */
-function shouldIgnorePath(configs, filePath, relativeFilePath) {
+function shouldIgnorePath(configs, filePath, relativeFilePath, path) {
 	let shouldIgnore = false;
 
 	for (const config of configs) {
+		const relativeFilePathToCheck = config.basePath
+			? toRelativePath(filePath, config.basePath, path)
+			: relativeFilePath;
 		shouldIgnore = config.ignores.reduce((ignored, matcher) => {
 			if (!ignored) {
 				if (typeof matcher === "function") {
@@ -488,7 +506,7 @@ function shouldIgnorePath(configs, filePath, relativeFilePath) {
 
 				// don't check negated patterns because we're not ignored yet
 				if (!matcher.startsWith("!")) {
-					return doMatch(relativeFilePath, matcher);
+					return doMatch(relativeFilePathToCheck, matcher);
 				}
 
 				// otherwise we're still not ignored
@@ -497,7 +515,7 @@ function shouldIgnorePath(configs, filePath, relativeFilePath) {
 
 			// only need to check negated patterns because we're ignored
 			if (typeof matcher === "string" && matcher.startsWith("!")) {
-				return !doMatch(relativeFilePath, matcher, {
+				return !doMatch(relativeFilePathToCheck, matcher, {
 					flipNegate: true,
 				});
 			}
@@ -639,20 +657,6 @@ function getPathImpl(fileOrDirPath) {
 	throw new Error(
 		`Expected an absolute path but received "${fileOrDirPath}"`,
 	);
-}
-
-/**
- * Converts a given path to a relative path with all separator characters replaced by forward slashes (`"/"`).
- * @param {string} fileOrDirPath The unprocessed path to convert.
- * @param {string} namespacedBasePath The namespaced base path of the directory to which the calculated path shall be relative.
- * @param {PathImpl} path Path-handling implementations.
- * @returns {string} A relative path with all separator characters replaced by forward slashes.
- */
-function toRelativePath(fileOrDirPath, namespacedBasePath, path) {
-	const fullPath = path.resolve(namespacedBasePath, fileOrDirPath);
-	const namespacedFullPath = path.toNamespacedPath(fullPath);
-	const relativePath = path.relative(namespacedBasePath, namespacedFullPath);
-	return relativePath.replaceAll(path.SEPARATOR, "/");
 }
 
 //------------------------------------------------------------------------------
@@ -989,13 +993,13 @@ export class ConfigArray extends Array {
 
 		// check to see if the file is outside the base path
 
-		const relativeFilePath = toRelativePath(
+		const relativeToBaseFilePath = toRelativePath(
 			filePath,
 			this.#namespacedBasePath,
 			this.#path,
 		);
 
-		if (EXTERNAL_PATH_REGEX.test(relativeFilePath)) {
+		if (EXTERNAL_PATH_REGEX.test(relativeToBaseFilePath)) {
 			debug(`No config for file ${filePath} outside of base path`);
 
 			// cache and return result
@@ -1014,7 +1018,14 @@ export class ConfigArray extends Array {
 			return CONFIG_WITH_STATUS_IGNORED;
 		}
 
-		if (shouldIgnorePath(this.ignores, filePath, relativeFilePath)) {
+		if (
+			shouldIgnorePath(
+				this.ignores,
+				filePath,
+				relativeToBaseFilePath,
+				this.#path,
+			)
+		) {
 			debug(`Ignoring ${filePath} based on file pattern`);
 
 			// cache and return result
@@ -1029,6 +1040,10 @@ export class ConfigArray extends Array {
 		const universalPattern = /^\*$|\/\*{1,2}$/u;
 
 		this.forEach((config, index) => {
+			const relativeFilePath = config.basePath
+				? toRelativePath(filePath, config.basePath, this.#path)
+				: relativeToBaseFilePath;
+
 			if (!config.files) {
 				if (!config.ignores) {
 					debug(`Universal config found for ${filePath}`);
@@ -1251,6 +1266,7 @@ export class ConfigArray extends Array {
 				this.ignores,
 				this.#path.join(this.basePath, relativeDirectoryToCheck),
 				relativeDirectoryToCheck,
+				this.#path,
 			);
 
 			cache.set(relativeDirectoryToCheck, result);

--- a/packages/config-array/src/config-array.js
+++ b/packages/config-array/src/config-array.js
@@ -201,6 +201,10 @@ function assertValidBaseConfig(config, index) {
 
 	const validateConfig = {};
 
+	if ("basePath" in config) {
+		validateConfig.basePath = config.basePath;
+	}
+
 	if ("files" in config) {
 		validateConfig.files = config.files;
 	}

--- a/packages/config-array/src/files-and-ignores-schema.js
+++ b/packages/config-array/src/files-and-ignores-schema.js
@@ -67,6 +67,17 @@ function assertIsNonEmptyArray(value) {
  * @type {ObjectDefinition}
  */
 export const filesAndIgnoresSchema = Object.freeze({
+	basePath: {
+		required: false,
+		merge() {
+			return undefined;
+		},
+		validate(value) {
+			if (typeof value !== "string") {
+				throw new TypeError("Expected value to be a string.");
+			}
+		},
+	},
 	files: {
 		required: false,
 		merge() {

--- a/packages/config-array/src/types.ts
+++ b/packages/config-array/src/types.ts
@@ -5,6 +5,11 @@
 
 export interface ConfigObject {
 	/**
+	 * The base path for files and ignores.
+	 */
+	basePath?: string;
+
+	/**
 	 * The files to include.
 	 */
 	files?: string[];

--- a/packages/config-array/tests/config-array.test.js
+++ b/packages/config-array/tests/config-array.test.js
@@ -3490,7 +3490,7 @@ describe("ConfigArray", () => {
 			it("should return all ignores from all configs without files when called", () => {
 				const expectedIgnores = configs.reduce((list, config) => {
 					if (config.ignores && Object.keys(config).length === 1) {
-						list.push(...config.ignores);
+						list.push(config);
 					}
 
 					return list;
@@ -3518,7 +3518,12 @@ describe("ConfigArray", () => {
 					configs.isFileIgnored("ignoreme/foo.js"),
 					true,
 				);
-				assert.deepStrictEqual(configs.ignores, ["ignoreme"]);
+				assert.deepStrictEqual(configs.ignores, [
+					{
+						name: "foo",
+						ignores: ["ignoreme"],
+					},
+				]);
 			});
 		});
 

--- a/packages/config-helpers/src/define-config.js
+++ b/packages/config-helpers/src/define-config.js
@@ -379,6 +379,12 @@ function extendConfig(baseConfig, baseConfigName, extension, extensionName) {
 
 	result.name = `${baseConfigName} > ${extensionName}`;
 
+	// @ts-ignore -- ESLint types aren't updated yet
+	if (baseConfig.basePath) {
+		// @ts-ignore -- ESLint types aren't updated yet
+		result.basePath = baseConfig.basePath;
+	}
+
 	return result;
 }
 
@@ -436,6 +442,10 @@ function processExtends(config, configNames) {
 		objectExtends,
 	)) {
 		const extension = /** @type {Config} */ (extendsElement);
+
+		if ("basePath" in extension) {
+			throw new TypeError("'basePath' in `extends` is not allowed.");
+		}
 
 		if ("extends" in extension) {
 			throw new TypeError("Nested 'extends' is not allowed.");


### PR DESCRIPTION
Proof of concept for the RFC Support `basePath` property in config objects.